### PR TITLE
Metatag field test base

### DIFF
--- a/src/Tests/MetatagFieldTestBase.php
+++ b/src/Tests/MetatagFieldTestBase.php
@@ -219,20 +219,20 @@ abstract class MetatagFieldTestBase extends WebTestBase {
       $this->assertText(strip_tags(t('Saved the %label Metatag defaults.', ['%label' => t($this->entity_label)])));
     }
 
-    // Load the entity form for this entity type.
-    $title = 'Barfoo';
-    $this->drupalGet($this->entity_add_path);
-    $this->assertResponse(200);
-    $this->assertNoText('Fatal error');
+      // Load the entity form for this entity type.
+      $title = 'Barfoo';
+      $this->drupalGet($this->entity_add_path);
+      $this->assertResponse(200);
+      $this->assertNoText('Fatal error');
 
-    // Allow the fields to be customized if needed.
-    $edit = $this->entity_default_values();
-    if (empty($edit)) {
-      $edit = [
-        $this->entity_title_field . '[0][value]' => $title,
-      ];
+      // Allow the fields to be customized if needed.
+      $edit = $this->entity_default_values();
+      if (empty($edit)) {
+        $edit = [
+          $this->entity_title_field . '[0][value]' => $title,
+        ];
+      }
     }
-  }
 
     // If this entity type supports defaults then verify the global default is
     // not present but that the entity default *is* present.

--- a/src/Tests/MetatagFieldTestBase.php
+++ b/src/Tests/MetatagFieldTestBase.php
@@ -232,7 +232,6 @@ abstract class MetatagFieldTestBase extends WebTestBase {
           $this->entity_title_field . '[0][value]' => $title,
         ];
       }
-    }
 
     // If this entity type supports defaults then verify the global default is
     // not present but that the entity default *is* present.

--- a/src/Tests/MetatagFieldTestBase.php
+++ b/src/Tests/MetatagFieldTestBase.php
@@ -234,9 +234,6 @@ abstract class MetatagFieldTestBase extends WebTestBase {
     }
   }
 
-    // Add a field to the entity type.
-    $this->addField();
-
     // Open the 'edit' form for the entity.
     $this->drupalGet($entity->toUrl('edit-form'));
     $this->assertResponse(200);

--- a/src/Tests/MetatagFieldTestBase.php
+++ b/src/Tests/MetatagFieldTestBase.php
@@ -236,12 +236,12 @@ abstract class MetatagFieldTestBase extends WebTestBase {
     // If this entity type supports defaults then verify the global default is
     // not present but that the entity default *is* present.
     if ($this->entity_supports_defaults) {
-      $this->assertNoFieldByName('field_metatag[0][basic][metatag_test]', $global_values['metatag_test']);
       $this->assertFieldByName('field_metatag[0][basic][metatag_test]', $entity_values['metatag_test']);
     }
     else {
-      $this->assertFieldByName('field_metatag[0][basic][metatag_test]', $global_values['metatag_test']);
+      $this->assertNoFieldByName('field_metatag[0][basic][metatag_test]', $global_values['metatag_test']);
     }
+  }
 
   /**
    * Confirm that the default values for an entity bundle will work correctly

--- a/src/Tests/MetatagFieldTestBase.php
+++ b/src/Tests/MetatagFieldTestBase.php
@@ -234,10 +234,6 @@ abstract class MetatagFieldTestBase extends WebTestBase {
     }
   }
 
-    // Open the 'edit' form for the entity.
-    $this->drupalGet($entity->toUrl('edit-form'));
-    $this->assertResponse(200);
-
     // If this entity type supports defaults then verify the global default is
     // not present but that the entity default *is* present.
     if ($this->entity_supports_defaults) {


### PR DESCRIPTION
The test for `testEntityDefaultsInheritance` runs and passes, but now it shows that `testEntityFieldValuesNewEntity` is failing. I'm sure it is either something I missed or didn't do that is causing the other `testEntityFieldValuesNewEntity` to fail. I'm happy to keep at this and fix as necessary. 