### PR TITLE
Fix MetatagToken::replace() signature.

### DIFF
--- a/src/MetatagToken.php
+++ b/src/MetatagToken.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Drupal\metatag;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Utility\Token;
 
 /**
@@ -37,7 +38,7 @@ class MetatagToken {
   public function replace($string, $data, $options = []) {
     $options['clear'] = TRUE;
 
-    $replaced = $this->token->replace($string, $data, $options);
+    $replaced = $this->token->replace($string, $data, $options, new BubbleableMetadata());
 
     // Ensure that there are no double-slash sequences due to empty token
     // values.


### PR DESCRIPTION
In order to avoid a 'LogicException: The controller result claims to be providing relevant cache Metadata, but leaked metadata was detected' and fail to render the page.

The method Token::replace() uses 4 arguments. MetatagToken::replace() only pass 3 arguments. This can lead to unwanted behavior when rendering pages and/or sending responses in a controller.

See the same issue for another module here: https://github.com/md-systems/pathauto/issues/64